### PR TITLE
Remove #ifdef EEPROM macros and trim Python plumbing code

### DIFF
--- a/TEST_APPS/device/nfcapp/main.cpp
+++ b/TEST_APPS/device/nfcapp/main.cpp
@@ -67,7 +67,7 @@ void wrap_printf(const char *f, va_list a)
 
 
 /** Disables VT100 etc. for easy manual UI interaction */
-int seteasy(int argc, char *argv[])
+int set_easy_printer(int argc, char *argv[])
 {
     const char msg[][20] =
     { "echo off", "set --retcode true", "set --vt100 off" };
@@ -76,6 +76,7 @@ int seteasy(int argc, char *argv[])
     }
     return (CMDLINE_RETCODE_SUCCESS);
 }
+
 
 /**
  * This test app can be used standalone interactively with at 115200 baud terminal. It is designed to work with the
@@ -93,6 +94,8 @@ int seteasy(int argc, char *argv[])
 int main()
 {
     cmd_init(&wrap_printf);
+    HandleTestCommand handleCommands; // For handling test commands and set nfc message queue
+
     cmd_add("getlastnfcerror", HandleTestCommand::cmd_get_last_nfc_error,
             "last NFC error code", errorcodes);
     cmd_add("setlastnfcerror", HandleTestCommand::cmd_set_last_nfc_error,
@@ -127,7 +130,7 @@ int main()
             "get supported protocols", "returns CSV list, see setprotocols");
     cmd_add("setprotocols", HandleTestCommand::cmd_configure_rf_protocols,
             "set rf protocols", "-p [t1t]/[t2t]/[t3t]/[isodep]/[nfcdep]/[t5t]");
-    cmd_add("easy", seteasy, "Use human readable terminal output",
+    cmd_add("easy", set_easy_printer, "Use human readable terminal output",
             "echo off,vt100 off,return-codes visible");
     cmd_add("trace", HandleTestCommand::cmd_set_trace, "detailed tracing on/off, ",
             "Defaults to enabled; values like 'on','true','1' all turn it on, anything else turns off detailed tracing.");
@@ -146,7 +149,6 @@ int main()
 #endif
     {
         int c;
-        HandleTestCommand handleCommands; // For handling test commands and set nfc message queue
         while ((c = getc(stdin)) != EOF) {
             cmd_char_input(c);
         }

--- a/TEST_APPS/device/nfcapp/main.cpp
+++ b/TEST_APPS/device/nfcapp/main.cpp
@@ -35,35 +35,36 @@ using mbed::nfc::NFCEEPROMDriver;
 
 #endif // MBED_CONF_NFCEEPROM
 
+const char *errorcodes = // descriptions from nfc/stack/nfc_errors.h
+    " 0 NFC_OK\r\n"
+    " 1 NFC_ERR_UNKNOWN\r\n"
+    " 2 NFC_ERR_LENGTH\r\n"
+    " 3 NFC_ERR_NOT_FOUND\r\n"
+    " 4 NFC_ERR_UNSUPPORTED\r\n"
+    " 5 NFC_ERR_PARAMS\r\n"
+    " 6 NFC_ERR_BUFFER_TOO_SMALL\r\n"
+    " 7 NFC_ERR_TIMEOUT\r\n"
+    " 8 NFC_ERR_CRC\r\n"
+    " 9 NFC_ERR_NOPEER\r\n"
+    "10 NFC_ERR_PARITY\r\n"
+    "11 NFC_ERR_FIELD\r\n"
+    "12 NFC_ERR_COLLISION\r\n"
+    "13 NFC_ERR_WRONG_COMM\r\n"
+    "14 NFC_ERR_PROTOCOL\r\n"
+    "15 NFC_ERR_BUSY\r\n"
+    "16 NFC_ERR_CONTROLLER\r\n"
+    "17 NFC_ERR_HALTED\r\n"
+    "18 NFC_ERR_MAC\r\n"
+    "19 NFC_ERR_UNDERFLOW\r\n"
+    "20 NFC_ERR_DISCONNECTED\r\n"
+    "21 NFC_ERR_ABORTED\r\n";
+
 
 void wrap_printf(const char *f, va_list a)
 {
     vprintf(f, a);
 }
 
-const char *errorcodes = // descriptions from nfc/stack/nfc_errors.h
-    " 0 NFC_OK \n"
-    " 1 NFC_ERR_UNKNOWN\n"
-    " 2 NFC_ERR_LENGTH \n"
-    " 3 NFC_ERR_NOT_FOUND\n"
-    " 4 NFC_ERR_UNSUPPORTED\n"
-    " 5 NFC_ERR_PARAMS \n"
-    " 6 NFC_ERR_BUFFER_TOO_SMALL\n"
-    " 7 NFC_ERR_TIMEOUT\n"
-    " 8 NFC_ERR_CRC\n"
-    " 9 NFC_ERR_NOPEER \n"
-    "10 NFC_ERR_PARITY \n"
-    "11 NFC_ERR_FIELD\n"
-    "12 NFC_ERR_COLLISION\n"
-    "13 NFC_ERR_WRONG_COMM \n"
-    "14 NFC_ERR_PROTOCOL \n"
-    "15 NFC_ERR_BUSY \n"
-    "16 NFC_ERR_CONTROLLER \n"
-    "17 NFC_ERR_HALTED \n"
-    "18 NFC_ERR_MAC\n"
-    "19 NFC_ERR_UNDERFLOW\n"
-    "20 NFC_ERR_DISCONNECTED \n"
-    "21 NFC_ERR_ABORTED\n";
 
 /** Disables VT100 etc. for easy manual UI interaction */
 int seteasy(int argc, char *argv[])
@@ -75,6 +76,7 @@ int seteasy(int argc, char *argv[])
     }
     return (CMDLINE_RETCODE_SUCCESS);
 }
+
 /**
  * This test app can be used standalone interactively with at 115200 baud terminal. It is designed to work with the
  * IceTea test framework https://os.mbed.com/docs/latest/tools/icetea-testing-applications.html . This app does
@@ -88,7 +90,7 @@ int seteasy(int argc, char *argv[])
  * If using an NFC EEPROM, an extra library is needed. Please see the documentation in the README.MD for instructions
  * on how to modify this test for new drivers/targets, and the steps to run this test suite.
  */
-int main(int argc, char *argv[])
+int main()
 {
     cmd_init(&wrap_printf);
     cmd_add("getlastnfcerror", HandleTestCommand::cmd_get_last_nfc_error,
@@ -127,6 +129,8 @@ int main(int argc, char *argv[])
             "set rf protocols", "-p [t1t]/[t2t]/[t3t]/[isodep]/[nfcdep]/[t5t]");
     cmd_add("easy", seteasy, "Use human readable terminal output",
             "echo off,vt100 off,return-codes visible");
+    cmd_add("trace", HandleTestCommand::cmd_set_trace, "detailed tracing on/off, ",
+            "Defaults to enabled; values like 'on','true','1' all turn it on, anything else turns off detailed tracing.");
 
 #if MBED_CONF_NFCEEPROM
     cmd_printf("MBED NFC EEPROM defined\r\n");
@@ -135,16 +139,17 @@ int main(int argc, char *argv[])
 #endif
 
 #ifdef TARGET_M24SR
-    cmd_printf("Using driver:M24SR\r\n");
+    cmd_printf("Using driver: M24SR\r\n");
 #endif
 #ifdef TARGET_PN512
-    cmd_printf("Using driver:PN512\r\n");
+    cmd_printf("Using driver: PN512\r\n");
 #endif
-
-    int c;
-    HandleTestCommand handleCommands; // starts handling nfc messages
-    while ((c = getc(stdin)) != EOF) {
-        cmd_char_input(c);
+    {
+        int c;
+        HandleTestCommand handleCommands; // For handling test commands and set nfc message queue
+        while ((c = getc(stdin)) != EOF) {
+            cmd_char_input(c);
+        }
     }
     return 0;
 }

--- a/TEST_APPS/device/nfcapp/nfccommands.cpp
+++ b/TEST_APPS/device/nfcapp/nfccommands.cpp
@@ -15,6 +15,7 @@
  */
 #include <string>
 #include <vector>
+#include <stdarg.h>
 #include <stdlib.h>
 #include "mbed_events.h"
 #include "mbed-client-cli/ns_cmdline.h"
@@ -29,32 +30,80 @@
 
 using mbed::nfc::nfc_rf_protocols_bitmask_t;
 
-events::EventQueue nfcQueue;
-rtos::Thread nfcThread;
-NFCTestShim *pNFC_Test_Shim = NULL;
+events::EventQueue HandleTestCommand::_nfcQueue;
 
-NFCTestShim *new_testshim()
+rtos::Thread nfcThread;
+bool human_trace_enabled = true;
+
+NFCTestShim *HandleTestCommand::new_testshim()
 {
 #if MBED_CONF_NFCEEPROM
-    mbed::nfc::NFCEEPROMDriver &eeprom_driver = get_eeprom_driver(nfcQueue);
+    mbed::nfc::NFCEEPROMDriver &eeprom_driver = get_eeprom_driver(_nfcQueue);
 
-    return ((NFCTestShim *)(new NFCProcessEEPROM(nfcQueue, eeprom_driver)));
+    return ((NFCTestShim *)(new NFCProcessEEPROM(_nfcQueue, eeprom_driver)));
 #else
-    return ((NFCTestShim *)(new NFCProcessController(nfcQueue)));
+    return ((NFCTestShim *)(new NFCProcessController(_nfcQueue)));
 #endif // EEPROM
 
 }
 
-void nfcRoutine()
+void HandleTestCommand::nfc_routine()
 {
-    nfcQueue.dispatch_forever();
+    _nfcQueue.dispatch_forever();
+}
+
+void trace_printf(const char *fmt, ...)
+{
+    if (human_trace_enabled) {
+        va_list ap;
+        va_start(ap, fmt);
+        cmd_vprintf(fmt, ap);
+        va_end(ap);
+    }
 }
 
 HandleTestCommand::HandleTestCommand()
 {
-    osStatus status = nfcThread.start(mbed::callback(&nfcRoutine));
+    osStatus status = nfcThread.start(mbed::callback(&HandleTestCommand::nfc_routine));
     MBED_ASSERT(status == osOK);
 }
+
+int HandleTestCommand::cmd_get_last_nfc_error(int argc, char *argv[])
+{
+    _nfcQueue.call(NFCTestShim::cmd_get_last_nfc_error);
+    return (CMDLINE_RETCODE_EXCUTING_CONTINUE);
+}
+
+/** returns compile time flag if NFC EEPROM was compiled */
+int HandleTestCommand::cmd_get_conf_nfceeprom(int argc, char *argv[])
+{
+    _nfcQueue.call(NFCTestShim::cmd_get_conf_nfceeprom);
+    return (CMDLINE_RETCODE_EXCUTING_CONTINUE);
+}
+
+
+
+int HandleTestCommand::cmd_set_trace(int argc, char *argv[])
+{
+    human_trace_enabled = false;
+    if (argc > 1) {
+        static char buffer[7];
+        char *p_buffer = buffer;
+        strncpy(buffer, argv[1], sizeof(buffer) - 1);
+        buffer[sizeof(buffer) - 1] = 0;
+        while (*p_buffer) {
+            *p_buffer = toupper(*p_buffer);
+            p_buffer++;
+        }
+        cmd_printf(buffer);
+        human_trace_enabled = (0 == strcmp(buffer, "TRUE")) || (0 == strcmp(buffer, "1")) || (0 == strcmp(buffer, "ON"));
+    }
+    cmd_printf("set trace '%s'", (human_trace_enabled ? "true" : "false"));
+    return (CMDLINE_RETCODE_SUCCESS);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////
 
 int HandleTestCommand::cmd_set_last_nfc_error(int argc, char *argv[])
 {
@@ -63,7 +112,7 @@ int HandleTestCommand::cmd_set_last_nfc_error(int argc, char *argv[])
         return (CMDLINE_RETCODE_INVALID_PARAMETERS);
     } else {
         int value = strtol(argv[1], NULL, 10);
-        nfcQueue.call(NFCTestShim::cmd_set_last_nfc_error, value);
+        _nfcQueue.call(NFCTestShim::cmd_set_last_nfc_error, value);
     }
     return (CMDLINE_RETCODE_EXCUTING_CONTINUE);
 }
@@ -72,7 +121,7 @@ int HandleTestCommand::cmd_set_last_nfc_error(int argc, char *argv[])
 int HandleTestCommand::cmd_get_max_ndef(int argc, char *argv[])
 {
     if (pNFC_Test_Shim) {
-        nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_get_max_ndef);
+        _nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_get_max_ndef);
         return CMDLINE_RETCODE_EXCUTING_CONTINUE;
     }
     return CMDLINE_RETCODE_FAIL;
@@ -81,19 +130,18 @@ int HandleTestCommand::cmd_get_max_ndef(int argc, char *argv[])
 
 int HandleTestCommand::cmd_init_nfc(int argc, char *argv[])
 {
-
     if (pNFC_Test_Shim) {
         cmd_printf("WARN init called again!\r\n"); // only legal here, if eeprom driver stops talking
     } else {
         pNFC_Test_Shim = new_testshim();
     }
-    nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_init);
+    _nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_init);
     return (CMDLINE_RETCODE_EXCUTING_CONTINUE);
 }
 
 int HandleTestCommand::cmd_read_message(int argc, char *argv[])
 {
-    nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_read_nfc_contents);
+    _nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_read_nfc_contents);
 
     return (CMDLINE_RETCODE_EXCUTING_CONTINUE);
 }
@@ -109,8 +157,8 @@ int HandleTestCommand::cmd_set_smartposter(int argc, char *argv[])
         char *uri = (char *) malloc(strlen(argv[1]) + 1);
         if (uri) {
             strcpy(uri, argv[1]);
-            nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_set_smartposter,
-                          uri); // called thread must free
+            _nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_set_smartposter,
+                           uri); // called thread must free
         } else {
             cmd_printf("WARN out of memory!\r\n");
             return (CMDLINE_RETCODE_FAIL);
@@ -119,10 +167,9 @@ int HandleTestCommand::cmd_set_smartposter(int argc, char *argv[])
     return (CMDLINE_RETCODE_EXCUTING_CONTINUE);
 }
 
-// todo: jira IOTPAN-295
 int HandleTestCommand::cmd_erase(int argc, char *argv[])
 {
-    nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_erase);
+    _nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_erase);
     return (CMDLINE_RETCODE_EXCUTING_CONTINUE);
 }
 
@@ -169,31 +216,31 @@ int HandleTestCommand::cmd_write_long_ndef_message(int argc, char *argv[])
     data[length] = '\0';
 
     // method must release buffer
-    nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_write_long, data);
+    _nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_write_long, data);
     return (CMDLINE_RETCODE_EXCUTING_CONTINUE);
 }
 
 int HandleTestCommand::cmd_start_discovery(int argc, char *argv[])
 {
     if ((argc > 1) && (0 == strcmp(argv[1], "man"))) {
-        cmd_printf("User must restart discovery manually()\r\n");
-        nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_start_discovery, false);
+        trace_printf("User must restart discovery manually()\r\n");
+        _nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_start_discovery, false);
     } else {
-        cmd_printf("App will restart discovery loop on auto()\r\n");
-        nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_start_discovery, true);
+        trace_printf("App will restart discovery loop on auto()\r\n");
+        _nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_start_discovery, true);
     }
     return (CMDLINE_RETCODE_EXCUTING_CONTINUE);
 }
 
 int HandleTestCommand::cmd_stop_discovery(int argc, char *argv[])
 {
-    nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_stop_discovery);
+    _nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_stop_discovery);
     return (CMDLINE_RETCODE_EXCUTING_CONTINUE);
 }
 
 int HandleTestCommand::cmd_get_supported_rf_protocols(int argc, char *argv[])
 {
-    nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_get_rf_protocols);
+    _nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_get_rf_protocols);
     return (CMDLINE_RETCODE_EXCUTING_CONTINUE);
 }
 
@@ -234,38 +281,8 @@ int HandleTestCommand::cmd_configure_rf_protocols(int argc, char *argv[])
         }
         argindex--;
     }
-    nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_configure_rf_protocols,
-                  protocols);
+    _nfcQueue.call(pNFC_Test_Shim, &NFCTestShim::cmd_configure_rf_protocols,
+                   protocols);
     return (CMDLINE_RETCODE_EXCUTING_CONTINUE);
-}
-
-// todo: implement
-int cmd_start_stop_discovery_wait_tag(int argc, char *argv[])
-{
-
-    return (CMDLINE_RETCODE_COMMAND_NOT_IMPLEMENTED);
-}
-
-/////////////////////////////////////////////////////////////////////
-// boilerplate only
-
-int cmd_is_iso7816_supported(int argc, char *argv[])
-{
-    return (CMDLINE_RETCODE_COMMAND_NOT_IMPLEMENTED);
-}
-
-int cmd_add_iso7816_application(int argc, char *argv[])
-{
-    return (CMDLINE_RETCODE_COMMAND_NOT_IMPLEMENTED);
-}
-
-int cmd_set_tagtype(int argc, char *argv[])
-{
-    return (CMDLINE_RETCODE_COMMAND_NOT_IMPLEMENTED);
-}
-
-int cmd_get_tagtype(int argc, char *argv[])
-{
-    return (CMDLINE_RETCODE_COMMAND_NOT_IMPLEMENTED);
 }
 

--- a/TEST_APPS/device/nfcapp/nfcprocessCtrl.h
+++ b/TEST_APPS/device/nfcapp/nfcprocessCtrl.h
@@ -48,11 +48,7 @@ class NFCProcessController: NFCTestShim,
 public:
     NFCProcessController(events::EventQueue &queue);
 
-    void cmd_get_max_ndef()
-    {
-        cmd_printf("{{maxndef=%d}}\r\n", (int)MBED_CONF_APP_TEST_NDEF_MSG_MAX);
-        cmd_ready(CMDLINE_RETCODE_SUCCESS);
-    }
+    void cmd_get_max_ndef();
     nfc_err_t init();
     nfc_err_t start_discovery();
     nfc_err_t stop_discovery();

--- a/TEST_APPS/device/nfcapp/nfctestshim.h
+++ b/TEST_APPS/device/nfcapp/nfctestshim.h
@@ -29,26 +29,22 @@
 #include "nfc/NFCDefinitions.h"
 
 /**
- * Test app driver wrapper. This is a base class containing shared EEPROM and Controller test data + logic
+ * Test app driver wrapper. This is a base class containing shared EEPROM and Controller test data + logic.
+ * Variations for the 2 different kinds of driver supported are delegated to derived classes.
  */
 class NFCTestShim {
 public:
     NFCTestShim(events::EventQueue &queue);
 
-    static void cmd_get_last_nfc_error()
-    {
-        get_last_nfc_error();
-    };
-    static void cmd_set_last_nfc_error(int err)
-    {
-        set_last_nfc_error(err);
-        cmd_ready(CMDLINE_RETCODE_SUCCESS);
-    };
-    static void cmd_get_conf_nfceeprom()
-    {
-        get_conf_nfceeprom();
-    };
+    static void cmd_get_last_nfc_error();
+    static void cmd_set_last_nfc_error(int err);
+    static void cmd_get_conf_nfceeprom();
+    /**
+     * For an EEPROM, this queries and responds with the flash size,
+     * For a Controller, responds with the config macro TEST_NDEF_MSG_MAX
+     */
     virtual void cmd_get_max_ndef() = 0;
+
     static void get_last_nfc_error();
     static void set_last_nfc_error(int err);
     static void get_conf_nfceeprom();
@@ -58,7 +54,6 @@ public:
     static char const *get_ndef_record_type_prefix(mbed::nfc::ndef::common::URI::uri_identifier_code_t id);
 
     void cmd_init();
-    virtual nfc_err_t init() = 0;
 
     void cmd_set_smartposter(char *cmdUri);
     void cmd_erase();
@@ -71,6 +66,7 @@ public:
 
 protected:
     // implement/declare EEPROM and Controller model underlying common BH and delegate specializations
+    virtual nfc_err_t init() = 0;
     virtual nfc_err_t set_rf_protocols(mbed::nfc::nfc_rf_protocols_bitmask_t protocols)
     {
         return NFC_ERR_UNSUPPORTED ;
@@ -99,7 +95,7 @@ protected:
 
 protected:
     size_t _ndef_write_buffer_used;
-    mbed::Span<uint8_t> ndef_poster_message; // message to build and send
+    mbed::Span<uint8_t> _ndef_poster_message; // message to build and send
     uint8_t _ndef_write_buffer[MBED_CONF_APP_TEST_NDEF_MSG_MAX]; // if this buffer is smaller than the EEPROM, the driver may crash see IOTPAN-297
     uint8_t _ndef_buffer[MBED_CONF_APP_TEST_NDEF_MSG_MAX];       // driver I/O buffer
     bool _discovery_restart;            // default true, restart discovery loop again on remote disconnect

--- a/TEST_APPS/testcases/nfc/nfc_clf_wrapper.py
+++ b/TEST_APPS/testcases/nfc/nfc_clf_wrapper.py
@@ -39,8 +39,7 @@ def debug_nfc_data(key, value):
     logger.info(text)
 
 
-logging.basicConfig(level=logging.DEBUG) # read commandline value?
-logger = logging.getLogger() 
+logger = logging.getLogger()
 
 
 class NfcWrapper:

--- a/TEST_APPS/testcases/nfc/test_nfc.py
+++ b/TEST_APPS/testcases/nfc/test_nfc.py
@@ -56,11 +56,11 @@ class CreamSconeTests(Bench, CliHelper):
         Bench.__init__(self, **testcase_args)
 
     def setup(self):
-        try:
+        #try:
             self.clf = ContactlessCommandRunner()
-            self.clf.parse("mute")
-        except:
-            raise asserts.TestStepFail("Could not find NFC reader")
+            self.clf.nfc.mute()
+        #except:
+        #    raise asserts.TestStepFail("Could not find NFC reader")
 
     def teardown(self):
         self.logger.info("Test teardown: Reboot target...")
@@ -83,7 +83,7 @@ def test_nfce2e_target_found(self):
     if not eeprom:
         self.nfc_command("dev1", "start")
 
-    self.clf.parse("connect")
+    self.clf.nfc.connect()
     tag = self.clf.clf_response()
     asserts.assertNotNone(tag, "Could not connect to any tag")
 
@@ -103,7 +103,7 @@ def test_nfce2e_type4_found(self):
     if not eeprom:
         self.nfc_command("dev1", "start")
 
-    self.clf.parse("connect")
+    self.clf.nfc.connect()
     tag = self.clf.clf_response()
     asserts.assertNotNone(tag, "Could not connect to any tag")
 
@@ -129,7 +129,7 @@ def test_nfce2e_smartposter(self):
     # write poster tag to target
     self.command("dev1", "setsmartposter %s" % expectedURI)
 
-    self.clf.parse("connect")
+    self.clf.nfc.connect()
     tag = self.clf.clf_response()
     asserts.assertNotNone(tag, "Could not connect to any tag")
     asserts.assertEqual(1, len(tag.ndef.records), "expected number NDEF records")
@@ -156,7 +156,7 @@ def test_nfce2e_reprogrammed(self):
 
     # program a poster tag to target
     print("Write Smartposter MESSAGE wirelessly")
-    self.clf.parse("connect")
+    self.clf.nfc.connect()
     tag = self.clf.clf_response()
     asserts.assertNotNone(tag, "Could not connect to any tag")
     smartposter = nfc_messages.make_smartposter(expectedURI, ["en-US:Other search engines exist"])
@@ -164,13 +164,13 @@ def test_nfce2e_reprogrammed(self):
     self.logger.info("Remote programmed %d bytes Smartposter" % len(str(smartposter)))
 
     print("Write back Smartposter MESSAGE wirelessly")
-    self.clf.parse("connect")
+    self.clf.nfc.connect()
     tag = self.clf.clf_response()
     asserts.assertNotNone(tag, "Could not re-connect to any tag")
 
     asserts.assertEqual(tag.ndef.records[0].__class__.__name__, "SmartposterRecord", "expected SmartposterRecord")
     asserts.assertEqual(expectedURI, tag.ndef.records[0].uri_records[0].uri, "expected exact URI")
-    self.clf.parse("mute")    # disable radio, to allow a local session
+    self.clf.nfc.mute()    # disable radio, to allow a local session
 
     # verify in target
     response = self.nfc_command("dev1", "readmessage")
@@ -208,7 +208,7 @@ def test_nfce2e_read_stress(self):
     # write a large message to the tag via API, then read it wirelessly
     print("Write/set tag MESSAGE (%d) bytes" % textLength)
     self.nfc_command("dev1", "writelong %d %s" % (textLength,messageRep))
-    self.clf.parse("connect")
+    self.clf.nfc.connect()
     tag = self.clf.clf_response()
     asserts.assertNotNone(tag, "Could not connect to any tag")
 
@@ -249,7 +249,7 @@ def test_nfce2e_reprogrammed_stress(self):
 
     # program a large tag to target remotely
     print("Write tag MESSAGE wirelessly (%d) bytes" % len(str(message)))
-    self.clf.parse("connect")
+    self.clf.nfc.connect()
     tag = self.clf.clf_response()
     asserts.assertNotNone(tag, "Could not connect to any tag")
     nfc_messages.program_remote_tag(message, tag)
@@ -257,10 +257,10 @@ def test_nfce2e_reprogrammed_stress(self):
 
     # read device locally
     print("Read back tag MESSAGE wirelessly")
-    self.clf.parse("connect")
+    self.clf.nfc.connect()
     tag = self.clf.clf_response()
     asserts.assertNotNone(tag, "Could not re-connect to any tag")
-    self.clf.parse("mute") # disable the reader radio, to allow local access
+    self.clf.nfc.mute() # disable the reader radio, to allow local access
 
     # verify in target
     response = self.nfc_command("dev1", "readmessage")
@@ -285,26 +285,26 @@ def test_nfce2e_discovery_loop(self):
     # Automatic resume after disconnect can be turned off by using command "start man" , the default is "start auto" .
 
     if not eeprom:
-        self.clf.parse("connect")
+        self.clf.nfc.connect()
         tag = self.clf.clf_response()
         asserts.assertNone(tag, "post-init: Tag discovery loop should be stopped!")
         self.nfc_command("dev1", "stop")
         time.sleep(1)
 
-        self.clf.parse("connect")
+        self.clf.nfc.connect()
         tag = self.clf.clf_response()
         asserts.assertNone(tag, "post-stop: Tag discovery loop should be stopped!")
         self.nfc_command("dev1", "start")
         time.sleep(1)
 
-        self.clf.parse("connect")
+        self.clf.nfc.connect()
         tag = self.clf.clf_response()
         asserts.assertNotNone(tag, "Could not connect to any tag")
 
-        self.clf.parse("mute")
+        self.clf.nfc.mute()
         self.nfc_command("dev1", "stop")
         time.sleep(10)
-        self.clf.parse("connect")
+        self.clf.nfc.connect()
         tag = self.clf.clf_response()
         # test blocked by issue raised IOTPAN313 NFC Controller discovery can stop but cannot restart - PN512
         asserts.assertNone(tag, "post-restart: Tag discovery loop should be stopped!")

--- a/TEST_APPS/testcases/nfc/test_self.py
+++ b/TEST_APPS/testcases/nfc/test_self.py
@@ -132,7 +132,7 @@ can be read back.
 @test_case(CreamSconeSelfTests)
 def test_nfc_write_long(self):
     messageRep = 'thequickbrownfoxjumpedoverthelazydog' # repeating message written
-    textLength = STRESS_BUFFLEN       # 2K < x < 4K
+    textLength = STRESS_BUFFLEN / 2       # 2K < x < 4K
     # calculate actual message to compare to using the library
     message = nfc_messages.make_textrecord( nfc_messages.repeat_string_to_length(messageRep, textLength))
     expected_message = str(message)
@@ -176,6 +176,7 @@ def test_nfc_set_controller_protocols(self):
     response = self.nfc_command("dev1", "iseeprom")
     eeprom = response.parsed['iseeprom']
     if eeprom:
+        # eeproms do not allow target control
         self.logger.info("Test ignore - target includes NFCEEPROM: %s" % eeprom)
     else:
         self.nfc_command("dev1", "setprotocols t1t")


### PR DESCRIPTION
### Description

Extra Python plumbing removed, C++ test classes refactored to move code into class for eeprom/controller without using macros


### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

